### PR TITLE
Added Account Info Typing

### DIFF
--- a/solathon/client.py
+++ b/solathon/client.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional, Text
 from solathon.utils import validate_commitment
 from .publickey import PublicKey
 from .core.http import HTTPClient
-from .core.types import Commitment, RPCResponse
+from .core.types import AccountInfo, Commitment, RPCResponse
 from .transaction import Transaction
 
 ENDPOINTS = (
@@ -42,7 +42,7 @@ class Client:
         """
         self.http.refresh()
 
-    def get_account_info(self, public_key: PublicKey | Text, commitment: Optional[Commitment]=None) -> RPCResponse:
+    def get_account_info(self, public_key: PublicKey | Text, commitment: Optional[Commitment]=None) -> RPCResponse[AccountInfo]:
         """
         Returns all the account info for the specified public key.
 

--- a/solathon/client.py
+++ b/solathon/client.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional, Text
 from solathon.utils import validate_commitment
 from .publickey import PublicKey
 from .core.http import HTTPClient
-from .core.types import AccountInfo, Commitment, RPCResponse
+from .core.types import AccountInfo, BlockHash, Commitment, RPCResponse
 from .transaction import Transaction
 
 ENDPOINTS = (
@@ -351,7 +351,7 @@ class Client:
         return self.build_and_send_request("getProgramAccounts", [public_key])
 
     # Will switch to getFeeForMessage (latest)
-    def get_recent_blockhash(self, commitment: Optional[Commitment]=None) -> RPCResponse:
+    def get_recent_blockhash(self, commitment: Optional[Commitment]=None) -> RPCResponse[BlockHash]:
         """
         Returns the recent blockhash.
 

--- a/solathon/core/types.py
+++ b/solathon/core/types.py
@@ -1,15 +1,29 @@
-from typing import TypedDict, Literal, Any
+from typing import Generic, TypeVar, TypedDict, Literal, Any, Union
 
+T = TypeVar('T')
 
 class RPCError(TypedDict):
     status_code: int
     message: str
 
+class Context(TypedDict):
+    slot: int
+    apiVersion: int
 
-class RPCResponse(TypedDict):
+class Result(Generic[T], TypedDict):
+    context: Context
+    value: Union[T, None]
+
+class RPCResponse(Generic[T], TypedDict):
     jsonrpc: Literal["2.0"]
     id: int
-    result: Any
+    result: Result[T]
     error: RPCError
+
+class AccountInfo(TypedDict):
+    lamports: int
+    owner: str
+    executable: bool
+    rentEpoch: int
 
 Commitment = Literal["processed", "confirmed", "finalized", "recent", "single", "singleGossip", "root", "max"]

--- a/solathon/core/types.py
+++ b/solathon/core/types.py
@@ -26,4 +26,11 @@ class AccountInfo(TypedDict):
     executable: bool
     rentEpoch: int
 
+class FeeCalculator(TypedDict):
+    lamportsPerSignature: int
+
+class BlockHash(TypedDict):
+    blockhash: str
+    feeCalculator: FeeCalculator
+
 Commitment = Literal["processed", "confirmed", "finalized", "recent", "single", "singleGossip", "root", "max"]

--- a/solathon/core/types.py
+++ b/solathon/core/types.py
@@ -25,6 +25,8 @@ class AccountInfo(TypedDict):
     owner: str
     executable: bool
     rentEpoch: int
+    size: int
+    data: Union[str, dict[str, Any]]
 
 class FeeCalculator(TypedDict):
     lamportsPerSignature: int


### PR DESCRIPTION
This PR contains
- Account Info type hinting for RPCResponse
- Also added generic typing to RPCResponse result so that more generalized types can be assigned if needed in future(which also also be a good todo right now for existing types)
- Added BlockHash Type as well