### PR TITLE
add <Code> blocks for py codes in solana-pay/functions pages in docs

### DIFF
--- a/docs/pages/solana-pay/functions/create_qr.mdx
+++ b/docs/pages/solana-pay/functions/create_qr.mdx
@@ -30,6 +30,9 @@ Border width around the QR code
 ### Returns image stream in the form of BytesIO
 
 Example
+
+<Code>
+
 ```python
 from solathon.solana_pay import create_qr
 
@@ -46,7 +49,7 @@ with open("qr.png", "wb") as f:
 def render_image():
     qr_image.seek(0)
     return send_file(img_bytes_io, mimetype='image/png')
-
 ```
+</Code>
 
 > The complete example code can be found [here](https://github.com/SuperteamDAO/solathon/tree/master/example/solana_pay).

--- a/docs/pages/solana-pay/functions/create_transfer.mdx
+++ b/docs/pages/solana-pay/functions/create_transfer.mdx
@@ -23,6 +23,9 @@ Commitment option for `get_recent_blockhash`.
 ### Returns valid [Transaction](/models/transaction/transaction) request with given parameters
 
 Example
+
+<Code>
+
 ```python
 from solathon.solana_pay import create_transfer
 from solathon import Client, Keypair, PublicKey
@@ -38,5 +41,6 @@ amount = 0.01
 transfer: Transaction = create_transfer(client, customer, {
         "recipient": recipient, "amount": amount, "reference": reference})
 ```
+</Code>
 
 > The complete example code can be found [here](https://github.com/SuperteamDAO/solathon/tree/master/example/solana_pay).

--- a/docs/pages/solana-pay/functions/encode_url.mdx
+++ b/docs/pages/solana-pay/functions/encode_url.mdx
@@ -17,6 +17,9 @@ Data to encode into a transaction request URL or transfer request URL
 ### Returns encoded url string with data
 
 Example
+
+<Code>
+
 ```python
 from solathon.solana_pay import encode_url
 from solathon import Client, Keypair, PublicKey
@@ -37,5 +40,6 @@ url: str = encode_url({"recipient": recipient, "label": label, "message": messag
 link = "https://www.example.com"
 url: str = encode_url({"link": link, "label": label, "message": message })
 ```
+</Code>
 
 > The complete example code can be found [here](https://github.com/SuperteamDAO/solathon/tree/master/example/solana_pay).

--- a/docs/pages/solana-pay/functions/find_reference.mdx
+++ b/docs/pages/solana-pay/functions/find_reference.mdx
@@ -19,6 +19,9 @@ The signature of the transaction to validate.
 ### Returns [TransactionSignature](/solana-pay/types/transaction_signature)
 
 Example
+
+<Code>
+
 ```python
 from solathon import Client
 from solathon.solana_pay import find_reference
@@ -29,5 +32,6 @@ reference = "XYZ"
 
 sign: TransactionSignature = find_reference(client, reference)
 ```
+</Code>
 
 > The complete example code can be found [here](https://github.com/SuperteamDAO/solathon/tree/master/example/solana_pay).

--- a/docs/pages/solana-pay/functions/parse_url.mdx
+++ b/docs/pages/solana-pay/functions/parse_url.mdx
@@ -17,6 +17,9 @@ URL to parse.
 ### Returns [TransactionRequestURL](/solana-pay/types/transaction_request_url_params) | [TransferRequestURL](/solana-pay/types/transfer_request_url_params)
 
 Example
+
+<Code>
+
 ```python
 from solathon.solana_pay.types import TransferRequestURLParams, TransactionRequestURLParams
 from solathon.solana_pay import parse_url
@@ -29,5 +32,6 @@ transfer_fields: TransferRequestURLParams = parse_url(url)
 url = "solana:https://example.com?&label=Jungle+Cats+store&message=Jungle+Cats+store+-+your+order+-+%23001234"
 transaction_fields: TransactionRequestURLParams = parse_url(url)
 ```
+</Code>
 
 > The complete example code can be found [here](https://github.com/SuperteamDAO/solathon/tree/master/example/solana_pay).

--- a/docs/pages/solana-pay/functions/validate_transfer.mdx
+++ b/docs/pages/solana-pay/functions/validate_transfer.mdx
@@ -23,6 +23,9 @@ Commitment option for `get_recent_blockhash`.
 ### Returns [TransactionElement](/solana-pay/types/transaction_element)
 
 Example
+
+<Code>
+
 ```python
 from solathon.solana_pay import validate_transfer, find_reference
 
@@ -35,5 +38,6 @@ sign: TransactionSignature = find_reference(client, reference)
 validate_transfer(client, sign.signature, { "recipient": MERCHENT_WALLET, "amount": amount, "reference": [reference] })
 print("Transfer Validated")
 ```
+<Code>
 
 > The complete example code can be found [here](https://github.com/SuperteamDAO/solathon/tree/master/example/solana_pay).


### PR DESCRIPTION
add missing `<Code>` blocks for codes in solana-pay/functions pages in docs, so there will be a normal copy icon in the upper left corner.