### PR TITLE
Pythonic Alternative to Construct-based Code

### DIFF
--- a/solathon/core/layouts.py
+++ b/solathon/core/layouts.py
@@ -146,7 +146,7 @@ SYSTEM_INSTRUCTIONS_LAYOUT = Struct(
             1: ASSIGN_LAYOUT,
             2: TRANFER_LAYOUT,
             3: CREATE_ACCOUNT_WTIH_SEED_LAYOUT,
-            4: Pass,  # No args for ADVANCE_NONCE_ACCOUNT
+            4: Pass,  # Placeholder or Pass if no args for ADVANCE_NONCE_ACCOUNT
             5: WITHDRAW_NONCE_ACCOUNT_LAYOUT,
             6: INITIALIZE_NONCE_ACCOUNT_LAYOUT,
             7: AUTHORIZE_NONCE_ACCOUNT_LAYOUT,

--- a/solathon/core/layouts.py
+++ b/solathon/core/layouts.py
@@ -1,3 +1,5 @@
+# Developer reference: https://github.com/solana-labs/solana/blob/master/sdk/program/src/system_instruction.rs
+
 from dataclasses import dataclass, asdict
 from typing import Optional, Union, Type
 import struct

--- a/solathon/core/layouts.py
+++ b/solathon/core/layouts.py
@@ -1,7 +1,7 @@
 # Developer reference: https://github.com/solana-labs/solana/blob/master/sdk/program/src/system_instruction.rs
 
-from dataclasses import dataclass, asdict
-from typing import Optional, Union, Type
+from dataclasses import dataclass
+from typing import Optional, Union
 import struct
 
 @dataclass
@@ -77,6 +77,7 @@ class SystemInstructions:
                         WithdrawNonceAccount, InitializeNonceAccount, AuthorizeNonceAccount,
                         Allocate, AllocateWithSeed, AssignWithSeed, TransferWithSeed]] = None
 
+# Helper functions for packing and unpacking
 
 def pack_public_key(public_key: PublicKey) -> bytes:
     return public_key.value.encode("utf-8")
@@ -91,6 +92,8 @@ def unpack_rust_string(data: bytes) -> RustString:
     length = struct.unpack("<I", data[:4])[0]
     chars = data[4:].decode("utf-8")
     return RustString(length=length, chars=chars)
+
+# Pack and Unpack functions for SystemInstructions
 
 def pack_system_instruction(instruction: SystemInstructions) -> bytes:
     packed_data = struct.pack("<I", instruction.type)
@@ -114,42 +117,43 @@ def pack_system_instruction(instruction: SystemInstructions) -> bytes:
 def unpack_system_instruction(data: bytes) -> SystemInstructions:
     type_value = struct.unpack("<I", data[:4])[0]
     args_unpacker = {
-        InstructionType.CREATE_ACCOUNT: unpack_create_account,
-        InstructionType.ASSIGN: unpack_assign,
-        InstructionType.TRANSFER: unpack_transfer,
-        InstructionType.CREATE_ACCOUNT_WITH_SEED: unpack_create_account_with_seed,
-        InstructionType.WITHDRAW_NONCE_ACCOUNT: unpack_withdraw_nonce_account,
-        InstructionType.INITIALIZE_NONCE_ACCOUNT: unpack_initialize_nonce_account,
-        InstructionType.AUTHORIZE_NONCE_ACCOUNT: unpack_authorize_nonce_account,
-        InstructionType.ALLOCATE: unpack_allocate,
-        InstructionType.ALLOCATE_WITH_SEED: unpack_allocate_with_seed,
-        InstructionType.ASSIGN_WITH_SEED: unpack_assign_with_seed,
-        InstructionType.TRANSFER_WITH_SEED: unpack_transfer_with_seed,
+        0: unpack_create_account,
+        1: unpack_assign,
+        2: unpack_transfer,
+        3: unpack_create_account_with_seed,
+        4: unpack_withdraw_nonce_account,
+        5: unpack_initialize_nonce_account,
+        6: unpack_authorize_nonce_account,
+        7: unpack_allocate,
+        8: unpack_allocate_with_seed,
+        9: unpack_assign_with_seed,
+        10: unpack_transfer_with_seed,
     }[type_value]
     args_length = struct.unpack("<I", data[4:8])[0]
     args_data = data[8: 8 + args_length]
     args = args_unpacker(args_data)
     return SystemInstructions(type=type_value, args=args)
 
-# SYSTEM_INSTRUCTIONS_LAYOUT
+# Layouts
+
 SYSTEM_INSTRUCTIONS_LAYOUT = Struct(
     "type" / Int32ul,
     "args"
     / Switch(
         lambda this: this.type,
         {
-            InstructionType.CREATE_ACCOUNT: CREATE_ACCOUNT_LAYOUT,
-            InstructionType.ASSIGN: ASSIGN_LAYOUT,
-            InstructionType.TRANSFER: TRANFER_LAYOUT,
-            InstructionType.CREATE_ACCOUNT_WITH_SEED: CREATE_ACCOUNT_WTIH_SEED_LAYOUT,
-            InstructionType.ADVANCE_NONCE_ACCOUNT: Pass,  # No args
-            InstructionType.WITHDRAW_NONCE_ACCOUNT: WITHDRAW_NONCE_ACCOUNT_LAYOUT,
-            InstructionType.INITIALIZE_NONCE_ACCOUNT: INITIALIZE_NONCE_ACCOUNT_LAYOUT,
-            InstructionType.AUTHORIZE_NONCE_ACCOUNT: AUTHORIZE_NONCE_ACCOUNT_LAYOUT,
-            InstructionType.ALLOCATE: ALLOCATE_LAYOUT,
-            InstructionType.ALLOCATE_WITH_SEED: ALLOCATE_WITH_SEED_LAYOUT,
-            InstructionType.ASSIGN_WITH_SEED: ASSIGN_WITH_SEED_LAYOUT,
-            InstructionType.TRANSFER_WITH_SEED: TRANSFER_WITH_SEED_LAYOUT,
+            0: CREATE_ACCOUNT_LAYOUT,
+            1: ASSIGN_LAYOUT,
+            2: TRANFER_LAYOUT,
+            3: CREATE_ACCOUNT_WTIH_SEED_LAYOUT,
+            4: Pass,  # No args for ADVANCE_NONCE_ACCOUNT
+            5: WITHDRAW_NONCE_ACCOUNT_LAYOUT,
+            6: INITIALIZE_NONCE_ACCOUNT_LAYOUT,
+            7: AUTHORIZE_NONCE_ACCOUNT_LAYOUT,
+            8: ALLOCATE_LAYOUT,
+            9: ALLOCATE_WITH_SEED_LAYOUT,
+            10: ASSIGN_WITH_SEED_LAYOUT,
+            11: TRANSFER_WITH_SEED_LAYOUT,
         },
     ),
 )

--- a/solathon/core/layouts.py
+++ b/solathon/core/layouts.py
@@ -130,3 +130,26 @@ def unpack_system_instruction(data: bytes) -> SystemInstructions:
     args_data = data[8: 8 + args_length]
     args = args_unpacker(args_data)
     return SystemInstructions(type=type_value, args=args)
+
+# SYSTEM_INSTRUCTIONS_LAYOUT
+SYSTEM_INSTRUCTIONS_LAYOUT = Struct(
+    "type" / Int32ul,
+    "args"
+    / Switch(
+        lambda this: this.type,
+        {
+            InstructionType.CREATE_ACCOUNT: CREATE_ACCOUNT_LAYOUT,
+            InstructionType.ASSIGN: ASSIGN_LAYOUT,
+            InstructionType.TRANSFER: TRANFER_LAYOUT,
+            InstructionType.CREATE_ACCOUNT_WITH_SEED: CREATE_ACCOUNT_WTIH_SEED_LAYOUT,
+            InstructionType.ADVANCE_NONCE_ACCOUNT: Pass,  # No args
+            InstructionType.WITHDRAW_NONCE_ACCOUNT: WITHDRAW_NONCE_ACCOUNT_LAYOUT,
+            InstructionType.INITIALIZE_NONCE_ACCOUNT: INITIALIZE_NONCE_ACCOUNT_LAYOUT,
+            InstructionType.AUTHORIZE_NONCE_ACCOUNT: AUTHORIZE_NONCE_ACCOUNT_LAYOUT,
+            InstructionType.ALLOCATE: ALLOCATE_LAYOUT,
+            InstructionType.ALLOCATE_WITH_SEED: ALLOCATE_WITH_SEED_LAYOUT,
+            InstructionType.ASSIGN_WITH_SEED: ASSIGN_WITH_SEED_LAYOUT,
+            InstructionType.TRANSFER_WITH_SEED: TRANSFER_WITH_SEED_LAYOUT,
+        },
+    ),
+)


### PR DESCRIPTION
This PR replaces the original construct-based code with a more readable and flexible Pythonic alternative. 
It uses data classes, the struct module, and custom pack/unpack functions while preserving the original functionality.

This PR fixes #44 