### PR TITLE
Fix send_transaction method: updated incorrect method name from get_r…

### DIFF
--- a/solathon/client.py
+++ b/solathon/client.py
@@ -778,7 +778,7 @@ class Client:
         recent_blockhash = transaction.recent_blockhash
 
         if recent_blockhash is None:
-            blockhash_resp = self.get_recent_blockhash()
+            blockhash_resp = self.get_latest_blockhash()
             recent_blockhash = blockhash_resp.blockhash
 
         transaction.recent_blockhash = recent_blockhash


### PR DESCRIPTION
This pull request addresses a bug in the send_transaction method where an incorrect method (get_recent_blockhash) was used. The correct method name is get_latest_blockhash, and this fix updates the call to use the correct method.